### PR TITLE
log -> logrus

### DIFF
--- a/internal/tf5muxprovider/main.go
+++ b/internal/tf5muxprovider/main.go
@@ -1,7 +1,7 @@
 package tf5muxprovider
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 )

--- a/internal/tf5to6provider/main.go
+++ b/internal/tf5to6provider/main.go
@@ -1,7 +1,7 @@
 package tf5to6provider
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
 )

--- a/internal/tf6muxprovider/main.go
+++ b/internal/tf6muxprovider/main.go
@@ -1,7 +1,7 @@
 package tf6muxprovider
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
 )

--- a/internal/tf6to5provider/main.go
+++ b/internal/tf6to5provider/main.go
@@ -1,7 +1,7 @@
 package tf6to5provider
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 )

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)